### PR TITLE
Modify mockbin script to use env vars or custom npm config

### DIFF
--- a/bin/mockbin
+++ b/bin/mockbin
@@ -6,11 +6,17 @@ var app = require('../src')
 var cmd = require('commander')
 var pkg = require('../package')
 
+var options = {
+  port: process.env.MOCKBIN_PORT || process.env.npm_package_config_port,
+  quiet: process.env.MOCKBIN_QUIET || process.env.npm_package_config_quiet,
+  redis: process.env.MOCKBIN_REDIS || process.env.npm_package_config_redis
+}
+
 cmd
   .version(pkg.version)
-  .option('-p, --port <port>', 'HTTP server port', pkg.config.port)
-  .option('-q, --quiet', 'disable console logging', pkg.config.quiet)
-  .option('-r, --redis [dsn]', 'redis dsn', pkg.config.redis)
+  .option('-p, --port <port>', 'HTTP server port', options.port)
+  .option('-q, --quiet', 'disable console logging', options.quiet)
+  .option('-r, --redis [dsn]', 'redis dsn', options.redis)
   .parse(process.argv)
 
 app(cmd, function () {


### PR DESCRIPTION
### What ?
  I'm proposing a modification in the `./bin/mockbin` script to read the startup params from Environment Variables or from the `npm config` properties. Now it is correct reading the customized values. 

Example: 
If you set the port to `8001` with  `npm config set mockbin:port 8001` the server will listen the 8001 instead of 8080

### Why ?
  I was trying to use the docker image, but mockbin was not able to connect to redis instance. This happens because the `bin/mockbin` reads the config from `pkg.config.*` and this properties always have the default values from `package.json`.
  So I modified it to read from `process.env.npm_package_config_redis` then the custom config `npm config set mockbin:redis redis://redis:6379` will work properly.

**Probably fix** https://github.com/Mashape/mockbin/issues/48